### PR TITLE
Experimental PR: the relationship between src and benchmarks in FluxMLBenchmarks.jl

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -15,6 +15,10 @@ jobs:
       -
         name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup main branch locally without switching current branch
+        run: git fetch origin main:main
       -
         name: Setup julia
         uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,5 +1,8 @@
 name: Benchmark
 on:
+  push:
+    branches:
+      - 'dev-*'
   pull_request:
     branches:
       - main
@@ -22,7 +25,7 @@ jobs:
         id: benchmark
         name: Run benchmark
         run: |
-          julia --project=benchmark -e 'using Pkg; print(readdir()); print(readdir("benchmark")); print(read("$(pwd())/Project.toml",String)); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+          julia --project=benchmark -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
           julia --project=benchmark benchmark/runbenchmarks.jl
       -
         name: Print report

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ BenchmarkCI = "20533458-34a3-403d-a444-e18f38190b5b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,12 @@ uuid = "6680a82f-826c-4bff-bf11-7163c7cf257a"
 authors = ["Kyle Daruwalla <daruwalla@wisc.edu> and contributors"]
 version = "1.0.0-DEV"
 
+[deps]
+BenchmarkCI = "20533458-34a3-403d-a444-e18f38190b5b"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
 [compat]
 julia = "1"
 

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -2,15 +2,7 @@
 # https://github.com/kul-forbes/ProximalOperators.jl/tree/master/benchmark
 using ArgParse
 using PkgBenchmark
-using BenchmarkCI: displayjudgement, printresultmd, CIResult
-using Markdown
-
-function markdown_report(judgement)
-    md = sprint(printresultmd, CIResult(judgement = judgement))
-    md = replace(md, ":x:" => "❌")
-    md = replace(md, ":white_check_mark:" => "✅")
-    return md
-end
+using FluxMLBenchmarks: markdown_report, display_markdown_report
 
 function parse_commandline()
     s = ArgParseSettings()
@@ -59,7 +51,7 @@ function main()
     judgement = judge(group_target, group_baseline)
     report_md = markdown_report(judgement)
     write(joinpath(@__DIR__, "report.md"), report_md)
-    display(Markdown.parse(report_md))
+    display_markdown_report(report_md)
 end
 
 main()

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -33,19 +33,19 @@ function main()
             kwargs...
         )
 
-    target = parsed_args["target"]
-    group_target = benchmarkpkg(
-        dirname(@__DIR__),
-        mkconfig(id = target),
-        resultfile = joinpath(@__DIR__, "result-$(target).json"),
-        retune = parsed_args["retune"],
-    )
-
     baseline = parsed_args["baseline"]
     group_baseline = benchmarkpkg(
         dirname(@__DIR__),
         mkconfig(id = baseline),
         resultfile = joinpath(@__DIR__, "result-$(baseline).json"),
+        retune = parsed_args["retune"],
+    )
+
+    target = parsed_args["target"]
+    group_target = benchmarkpkg(
+        dirname(@__DIR__),
+        mkconfig(id = target),
+        resultfile = joinpath(@__DIR__, "result-$(target).json"),
     )
 
     judgement = judge(group_target, group_baseline)

--- a/src/FluxMLBenchmarks.jl
+++ b/src/FluxMLBenchmarks.jl
@@ -1,5 +1,10 @@
 module FluxMLBenchmarks
 
 # Write your package code here.
+include("env_utils.jl")
+export setup, teardown
+
+include("judge_utils.jl")
+export markdown_report, display_markdown_report
 
 end

--- a/src/env_utils.jl
+++ b/src/env_utils.jl
@@ -1,0 +1,20 @@
+using Pkg
+
+const BENCHMARK_PKG_PATH = "../benchmark/"
+
+function setup(deps::Vector{PackageSpec})
+    Pkg.activate(BENCHMARK_PKG_PATH)
+    cd(BENCHMARK_PKG_PATH)
+
+    for dep in deps
+        Pkg.add(dep)
+    end
+end
+
+
+function teardown()
+    Pkg.rm(all_pkgs = true)
+    pwd = ENV["PWD"] # PWD in ENV means the original path where run the code
+    Pkg.activate(pwd)
+    cd(pwd)
+end

--- a/src/judge_utils.jl
+++ b/src/judge_utils.jl
@@ -1,5 +1,5 @@
 using BenchmarkCI: printresultmd, CIResult
-using BenchmarkTools: BenchmarkJudgement
+using PkgBenchmark: BenchmarkJudgement
 using Markdown
 
 """

--- a/src/judge_utils.jl
+++ b/src/judge_utils.jl
@@ -1,0 +1,25 @@
+using BenchmarkCI: printresultmd, CIResult
+using BenchmarkTools: BenchmarkJudgement
+using Markdown
+
+"""
+    markdown_report(judgement::BenchmarkJudgement)
+
+Return markdown content (String) by the result of BenchmarkTools.judge.
+"""
+function markdown_report(judgement::BenchmarkJudgement)
+    md = sprint(printresultmd, CIResult(judgement = judgement))
+    md = replace(md, ":x:" => "❌")
+    md = replace(md, ":white_check_mark:" => "✅")
+    return md
+end
+
+
+"""
+    display_markdown_report(report_md)
+
+Display the content of the report after parsed by Markdown.parse.
+
+* report_md: the result of [`markdown_report`](@ref)
+"""
+display_markdown_report(report_md) = display(Markdown.parse(report_md))


### PR DESCRIPTION
### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable

### Structure

In #1 , I've copied and pasted into benchmarks of FluxMLBenchmarks.jl from the current benchmarks of NNlib.jl. NNlib.jl/benchmark/runbenchmarks.jl contains a `markdown_report` function, which is used to export the markdown content. 

This PR moved `markdown_report` from benchmark to src, which shows a direction that I'm going to make FluxMLBenchmarks.jl a repository including benchmarking tools and benchmark code. And I think this is also in line with my proposal and our previous discussions.

```julia
using FluxMLBenchmarks: markdown_report, display_markdown_report

# ignore some code

report_md = markdown_report(judgement)
write(joinpath(@__DIR__, "report.md"), report_md)
display(Markdown.parse(report_md))
display_markdown_report(report_md)
```

After this PR, the benchmark code in benchmark folder will tend to call tool functions defined in FluxMLBenchmarks.jl, which is designed as an abstract layer of BenchmarkTools.jl, PkgBenchmark.jl, BenchmarkCI.jl and so on.

<img width="1014" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/952322e7-8e71-4953-bbb2-0a1885503995">

In addition, I run the current workflow once under the condition of "tuning once" and "forcing tuning twice". Currently, the time required for tuning once is about 15 minutes (approximately), which is similar to the current scale of the benchmark.

<img width="1076" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/4a5c429c-3818-4e46-9029-f5ba005f307e">

I am not sure if the increasing tuning time will synchronize with the increase required to execute the benchmark under the current execution strategy (see below), but I suspect that both are important time-consuming points.

```julia
BenchmarkTools.DEFAULT_PARAMETERS.samples = 20
BenchmarkTools.DEFAULT_PARAMETERS.seconds = 2.5
```