### PR TITLE
Add benchmark for Flux.jl

### DIFF
--- a/benchmark/benchmark/flux.jl
+++ b/benchmark/benchmark/flux.jl
@@ -1,0 +1,13 @@
+using Flux
+
+model = Chain(
+    Flux.flatten,
+    Dense(32 * 32, 64, relu),
+    Dense(64, 10))
+
+SUITE["flux"] = BenchmarkGroup()
+SUITE["flux"]["mlp"] = BenchmarkGroup()
+for et in (Float16, Float32, Float64)
+    x = rand(et, 32, 32, 1, 5)
+    SUITE["flux"]["mlp"][string(et)] = @benchmarkable model($x)
+end

--- a/benchmark/benchmark/nnlib.jl
+++ b/benchmark/benchmark/nnlib.jl
@@ -1,0 +1,44 @@
+using NNlib
+using NNlib.ChainRulesCore: rrule
+using Random
+
+SUITE["activations"] = BenchmarkGroup()
+for et in (Float16, Float32, Float64)
+    et_suite = BenchmarkGroup()
+    SUITE["activations"][string(et)] = et_suite
+    let x = rand(et, 1024, 1024), y = similar(x)
+        for f in NNlib.ACTIVATIONS
+            act = @eval($f)
+            et_suite[string(f)] = @benchmarkable broadcast!($act, $y, $x)
+        end
+    end
+end
+
+for (fn!, fn_bw) in [(softmax!, NNlib.∇softmax_data), (logsoftmax!, NNlib.∇logsoftmax_data)]
+    fn_suite = BenchmarkGroup()
+    SUITE[rstrip(string(fn!), '!')] = fn_suite
+    let SIZES = [
+        (128, 384, 8),
+        (512, 784, 8),
+        (768, 1024, 4),
+        (1024, 2048, 4),
+        (2048, 2048, 2),
+        (4096, 2048, 2),
+        (4096, 4096, 2),
+        (12288, 2048, 1)
+    ]
+        for et in (Float16, Float32)
+            et_suite = BenchmarkGroup("fw" => BenchmarkGroup(), "bw" => BenchmarkGroup())
+            fn_suite[string(et)] = et_suite
+            for sz in SIZES
+                x = randn(et, sz)
+                y = similar(x)
+                dy = zero(x)
+                fn!(y, x)
+                et_suite["fw"][string(sz)] = @benchmarkable $fn!($y, $x)
+                et_suite["bw"][string(sz)] = @benchmarkable $fn_bw($dy, $y)
+            end
+        end
+    end
+end
+

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,49 +1,8 @@
 using BenchmarkTools
-using NNlib
-using NNlib.ChainRulesCore: rrule
 using Random
 
 Random.seed!(1234567890)
-
 const SUITE = BenchmarkGroup()
 
-SUITE["activations"] = BenchmarkGroup()
-for et in (Float16, Float32, Float64)
-    et_suite = BenchmarkGroup()
-    SUITE["activations"][string(et)] = et_suite
-    let x = rand(et, 1024, 1024), y = similar(x)
-        for f in NNlib.ACTIVATIONS
-            act = @eval($f)
-            et_suite[string(f)] = @benchmarkable broadcast!($act, $y, $x)
-        end
-    end
-end
-
-for (fn!, fn_bw) in [(softmax!, NNlib.∇softmax_data), (logsoftmax!, NNlib.∇logsoftmax_data)]
-    fn_suite = BenchmarkGroup()
-    SUITE[rstrip(string(fn!), '!')] = fn_suite
-    let SIZES = [
-        (128, 384, 8),
-        (512, 784, 8),
-        (768, 1024, 4),
-        (1024, 2048, 4),
-        (2048, 2048, 2),
-        (4096, 2048, 2),
-        (4096, 4096, 2),
-        (12288, 2048, 1)
-    ]
-        for et in (Float16, Float32)
-            et_suite = BenchmarkGroup("fw" => BenchmarkGroup(), "bw" => BenchmarkGroup())
-            fn_suite[string(et)] = et_suite
-            for sz in SIZES
-                x = randn(et, sz)
-                y = similar(x)
-                dy = zero(x)
-                fn!(y, x)
-                et_suite["fw"][string(sz)] = @benchmarkable $fn!($y, $x)
-                et_suite["bw"][string(sz)] = @benchmarkable $fn_bw($dy, $y)
-            end
-        end
-    end
-end
-
+include("benchmark/nnlib.jl")
+include("benchmark/flux.jl")


### PR DESCRIPTION
### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable

### Description

Just as our discussions last meeting, I create a simple MLP invoking some NNlib functions indirectly. I've tested locally; it works well. But currently it's still using `benchmarkpkg` and identical dependencies, and I'll create a branch in FluxMLBenchmark.jl later for adding hacked-NNlib.

Later, if everything goes well, I'd like to create a pull request on a dummy branch to patch NNlib, in order to slow down NNlib.