### PR TITLE
Experimental PR: run benchmarks locally with two specific version as dependency (target & baseline)

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -19,8 +19,8 @@ jobs:
   RunBenchmark:
     runs-on: ubuntu-latest
     env:
-      TARGET_URL: ${{ github.inputs.target_url || '${{ github.event.pull_request.head.repo.html_url }}#${{ github.event.pull_request.head.sha }}' }}
-      BASELINE_URL: ${{ github.inputs.baseline_url || '${{ github.event.pull_request.base.repo.html_url }}#${{ github.event.pull_request.base.sha }}' }}
+      TARGET_URL: ${{ github.event.inputs.target_url || '${{ github.event.pull_request.head.repo.html_url }}#${{ github.event.pull_request.head.sha }}' }}
+      BASELINE_URL: ${{ github.event.inputs.baseline_url || '${{ github.event.pull_request.base.repo.html_url }}#${{ github.event.pull_request.base.sha }}' }}
     steps:
       -
         run: |

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -7,11 +7,25 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      target_url:
+        type: string
+        description: url of target
+      baseline_url:
+        type: string
+        description: url of baseline
 
 jobs:
   RunBenchmark:
     runs-on: ubuntu-latest
+    env:
+      TARGET_URL: ${{ github.inputs.target_url || github.event.pull_request.head.repo.html_url + "#" + github.event.pull_request.head.sha }}
+      BASELINE_URL: ${{ github.inputs.baseline_url || github.event.pull_request.base.repo.html_url + "#" + github.event.pull_request.base.sha }}
     steps:
+      -
+        run: |
+          echo "Target repo url: $TARGET_URL"
+          echo "Baseline repo url: $BASELINE_URL"
       -
         name: Checkout code
         uses: actions/checkout@v3
@@ -29,7 +43,7 @@ jobs:
         id: benchmark
         name: Run benchmark
         run: |
-          julia --project=benchmark benchmark/runbenchmarks.jl
+          julia --project=benchmark benchmark/runbenchmarks.jl $TARGET_URL $BASELINE_URL
       -
         name: Print report
         run: |

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -19,8 +19,8 @@ jobs:
   RunBenchmark:
     runs-on: ubuntu-latest
     env:
-      TARGET_URL: ${{ github.inputs.target_url || github.event.pull_request.head.repo.html_url + "#" + github.event.pull_request.head.sha }}
-      BASELINE_URL: ${{ github.inputs.baseline_url || github.event.pull_request.base.repo.html_url + "#" + github.event.pull_request.base.sha }}
+      TARGET_URL: ${{ github.inputs.target_url || '${{ github.event.pull_request.head.repo.html_url }}#${{ github.event.pull_request.head.sha }}' }}
+      BASELINE_URL: ${{ github.inputs.baseline_url || '${{ github.event.pull_request.base.repo.html_url }}#${{ github.event.pull_request.base.sha }}' }}
     steps:
       -
         run: |

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -9,16 +9,17 @@ parsed_args = parse_commandline()
 baseline_url = parsed_args["baseline"]
 setup_fluxml_env(Vector([baseline_url]))
 
-using PkgBenchmark
-mkconfig(; kwargs...) = BenchmarkConfig(
-    env = Dict("JULIA_NUM_THREADS" => get(ENV, "JULIA_NUM_THREADS", "1"));
-    kwargs...
-)
+using BenchmarkTools
+BenchmarkTools.DEFAULT_PARAMETERS.samples = 20
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 2.5
 
+using PkgBenchmark
 group_baseline = benchmarkpkg(
     dirname(@__DIR__),
-    mkconfig(id = baseline),
-    resultfile = joinpath(@__DIR__, "result-$(baseline).json")
+    BenchmarkConfig(
+        env = Dict("JULIA_NUM_THREADS" => get(ENV, "JULIA_NUM_THREADS", "1"))
+    ),
+    resultfile = joinpath(@__DIR__, "result-baseline.json")
 )
 
 teardown()
@@ -28,14 +29,20 @@ teardown()
 Pkg.develop(PackageSpec(path = ENV["PWD"]))
 using FluxMLBenchmarks
 
-target = parsed_args["target"]
-setup_fluxml_env()
+target_url = parsed_args["target"]
+setup_fluxml_env(Vector([target_url]))
+
+using BenchmarkTools
+BenchmarkTools.DEFAULT_PARAMETERS.samples = 20
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 2.5
 
 using PkgBenchmark
 group_target = benchmarkpkg(
     dirname(@__DIR__),
-    mkconfig(id = target),
-    resultfile = joinpath(@__DIR__, "result-$(target).json"),
+    BenchmarkConfig(
+        env = Dict("JULIA_NUM_THREADS" => get(ENV, "JULIA_NUM_THREADS", "1"))
+    ),
+    resultfile = joinpath(@__DIR__, "result-target.json"),
 )
 
 teardown()

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -6,8 +6,8 @@ Pkg.develop(PackageSpec(path = ENV["PWD"]))
 using FluxMLBenchmarks
 parsed_args = parse_commandline()
 
-baseline = parsed_args["baseline"]
-setup_fluxml_env()
+baseline_url = parsed_args["baseline"]
+setup_fluxml_env(Vector([baseline_url]))
 
 using PkgBenchmark
 mkconfig(; kwargs...) = BenchmarkConfig(


### PR DESCRIPTION
### PR Checklist

- [ ] Tests are added
- [x] Documentation, if applicable

### Test

* [aefd2d0](https://github.com/FluxML/NNlib.jl/commit/aefd2d099368a70df55320e2d85f1a3b0828e716) is the commit id of [NNlib v0.8.21](https://github.com/FluxML/NNlib.jl/releases/tag/v0.8.21)
* [lppool](https://github.com/skyleaworlder/NNlib.jl/tree/lppool) is an old branch I developed whose original version is v0.8.10

```shell
> julia --project=benchmark benchmark/runbenchmarks.jl https://github.com/FluxML/NNlib.jl#aefd2d0 https://github.com/skyleaworlder/NNlib.jl#lppool
```

<img width="604" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/1ba3c8fc-ee1f-4cb0-9711-85e0d436bf8a">

* target:
  <img width="602" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/4593c681-ba7d-47cc-b9b8-4c61c8f50b58">
* baseline:
  <img width="601" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/293b14fa-c1ab-4240-8e27-01867a5899ab">

### Description

* Currently, FluxMLBenchmarks.jl doesn't use `benchmarkpkg` to checkout specific commit of **"FluxMLBenchmarks"** itself any longer, and it can handle command arguments as baseline and target.
* I refact the basic structure of "runbenchmarks.jl", make the main process of each section (baseline and target) more similar.
* I'm trying to make the workflow work properly, but perhaps I've encountered some difficulties. Therefore, the greater purpose of this PR is to make the benchmarks run by passing in the information (path that Pkg.jl need) of baseline and target through command args, rather than making GitHub Actions meet our expectations (and I think we need to discuss our expectations).