### PR TITLE
Support multiple dependencies

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -43,7 +43,7 @@ jobs:
         id: benchmark
         name: Run benchmark
         run: |
-          julia --project=benchmark benchmark/runbenchmarks.jl $TARGET_URL $BASELINE_URL
+          julia --project=benchmark benchmark/runbenchmarks-pr.jl --target=$TARGET_URL --baseline=$BASELINE_URL
       -
         name: Print report
         run: |

--- a/benchmark/runbenchmarks-cli.jl
+++ b/benchmark/runbenchmarks-cli.jl
@@ -1,0 +1,55 @@
+using Pkg
+
+###########################################################################
+
+Pkg.develop(PackageSpec(path = ENV["PWD"]))
+using FluxMLBenchmarks
+parsed_args = parse_commandline()
+deps_list = parsed_args["deps-list"]
+baseline_fluxml_deps, target_fluxml_deps = parse_deps_list(deps_list)
+
+setup_fluxml_env(baseline_fluxml_deps)
+
+using BenchmarkTools
+BenchmarkTools.DEFAULT_PARAMETERS.samples = 20
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 2.5
+
+using PkgBenchmark
+group_baseline = benchmarkpkg(
+    dirname(@__DIR__),
+    BenchmarkConfig(
+        env = Dict("JULIA_NUM_THREADS" => get(ENV, "JULIA_NUM_THREADS", "1"))
+    ),
+    resultfile = joinpath(@__DIR__, "result-baseline.json")
+)
+
+teardown()
+
+###########################################################################
+
+Pkg.develop(PackageSpec(path = ENV["PWD"]))
+using FluxMLBenchmarks
+
+setup_fluxml_env(target_fluxml_deps)
+
+using BenchmarkTools
+BenchmarkTools.DEFAULT_PARAMETERS.samples = 20
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 2.5
+
+using PkgBenchmark
+group_target = benchmarkpkg(
+    dirname(@__DIR__),
+    BenchmarkConfig(
+        env = Dict("JULIA_NUM_THREADS" => get(ENV, "JULIA_NUM_THREADS", "1"))
+    ),
+    resultfile = joinpath(@__DIR__, "result-target.json"),
+)
+
+teardown()
+
+###########################################################################
+
+judgement = judge(group_target, group_baseline)
+report_md = markdown_report(judgement)
+write(joinpath(@__DIR__, "report.md"), report_md)
+display_markdown_report(report_md)

--- a/benchmark/runbenchmarks-pr.jl
+++ b/benchmark/runbenchmarks-pr.jl
@@ -7,7 +7,7 @@ using FluxMLBenchmarks
 parsed_args = parse_commandline()
 
 baseline_url = parsed_args["baseline"]
-setup_fluxml_env(Vector([baseline_url]))
+setup_fluxml_env([baseline_url])
 
 using BenchmarkTools
 BenchmarkTools.DEFAULT_PARAMETERS.samples = 20
@@ -30,7 +30,7 @@ Pkg.develop(PackageSpec(path = ENV["PWD"]))
 using FluxMLBenchmarks
 
 target_url = parsed_args["target"]
-setup_fluxml_env(Vector([target_url]))
+setup_fluxml_env([target_url])
 
 using BenchmarkTools
 BenchmarkTools.DEFAULT_PARAMETERS.samples = 20

--- a/src/FluxMLBenchmarks.jl
+++ b/src/FluxMLBenchmarks.jl
@@ -2,7 +2,8 @@ module FluxMLBenchmarks
 
 # Write your package code here.
 include("env_utils.jl")
-export Dependency, get_name, init_dependencies, parse_commandline,
+export Dependency, get_name, init_dependencies,
+    parse_commandline, parse_deps_list,
     setup_fluxml_env, teardown
 
 include("judge_utils.jl")

--- a/test/env_utils_test.jl
+++ b/test/env_utils_test.jl
@@ -1,17 +1,23 @@
 @testset "env_utils_test" begin
 
     @testset "Dependency" begin
-        flux_dep = Dependency(name = "Flux")
+        flux_dep = Dependency("Flux")
         @test flux_dep.name == "Flux"
         
-        nnlib_dep = Dependency(name = "NNlib", version = "0.8.20")
+        nnlib_dep = Dependency("NNlib@0.8.20")
         @test (nnlib_dep.name == "NNlib" && nnlib_dep.version == "0.8.20")
     
-        zygote_dep = Dependency(name = "Zygote", rev = "2f4937096ee1db4b5a67c1c31fe3ebeab1c96c8c")
+        zygote_dep = Dependency("Zygote#2f4937096ee1db4b5a67c1c31fe3ebeab1c96c8c")
         @test (zygote_dep.name == "Zygote" && zygote_dep.rev == "2f4937096ee1db4b5a67c1c31fe3ebeab1c96c8c")
     
-        optimisers_dep = Dependency(url = "https://github.com/FluxML/Optimisers.jl")
-        @test optimisers_dep.url == "https://github.com/FluxML/Optimisers.jl" 
+        optimisers_dep = Dependency("https://github.com/FluxML/Optimisers.jl")
+        @test optimisers_dep.url == "https://github.com/FluxML/Optimisers.jl"
+
+        functors_dep = Dependency("https://github.com/FluxML/Functors.jl#master")
+        @test (functors_dep.url == "https://github.com/FluxML/Functors.jl" && functors_dep.rev == "master")
+
+        onehot_dep = Dependency("https://github.com/FluxML/OneHotArrays.jl@0.2.4")
+        @test (onehot_dep.url == "https://github.com/FluxML/OneHotArrays.jl" && onehot_dep.version == "0.2.4")
     end
 
     @testset "dependency operation" begin
@@ -28,4 +34,16 @@
         @test is_tested
     end
 
+    @testset "parse deps list" begin
+        deps_list = "NNlib,https://github.com/skyleaworlder/NNlib.jl#dummy-benchmark-test;Flux,Flux@0.13.12"
+        baseline_deps, target_deps = parse_deps_list(deps_list)
+        @test (length(baseline_deps) == 2 &&
+               baseline_deps[1].name == "NNlib" &&
+               baseline_deps[2].name == "Flux")
+        @test (length(target_deps) == 2 &&
+               target_deps[1].url == "https://github.com/skyleaworlder/NNlib.jl" &&
+               target_deps[1].rev == "dummy-benchmark-test" &&
+               target_deps[2].name == "Flux" &&
+               target_deps[2].version == "0.13.12")
+    end
 end


### PR DESCRIPTION
### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable

### Description

in the case of mutual influence between **multiple packages of different versions**, **2 sets of dependencies** need to be provided simultaneously. To meet this benchmarking requirements, you can use `--deps-list`:

```shell
> DEPS_LIST=<Dependencies List>
> julia --project=benchmark benchmark/runbenchmarks-cli.jl --deps-list=$DEPS_LIST
```

For specification, `Dependencies List` is a single string that simulates an array, with each element separated by a semicolon. Each element consists of two parts:

* the first part is a dependent version,
* the second part is another dependent version.

e.g.

```shell
> DEPS_LIST="https://github.com/FluxML/NNlib.jl#backports-0.8.21,https://github.com/skyleaworlder/NNlib.jl#dummy-benchmark-test;Flux,Flux@0.13.12"
> julia --project=benchmark benchmark/runbenchmarks-cli.jl --deps-list=$DEPS_LIST
```