### PR TITLE
Fix: Benchmark CI about string concatenation

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,8 +1,5 @@
 name: Benchmark
 on:
-  push:
-    branches:
-      - 'dev-*'
   pull_request:
     branches:
       - main
@@ -19,8 +16,8 @@ jobs:
   RunBenchmark:
     runs-on: ubuntu-latest
     env:
-      TARGET_URL: ${{ github.event.inputs.target_url || '${{ github.event.pull_request.head.repo.html_url }}#${{ github.event.pull_request.head.sha }}' }}
-      BASELINE_URL: ${{ github.event.inputs.baseline_url || '${{ github.event.pull_request.base.repo.html_url }}#${{ github.event.pull_request.base.sha }}' }}
+      TARGET_URL: ${{ github.event.inputs.target_url || format('{0}#{1}', github.event.pull_request.head.repo.html_url, github.event.pull_request.head.sha) }}
+      BASELINE_URL: ${{ github.event.inputs.baseline_url || format('{0}#{1}', github.event.pull_request.base.repo.html_url, github.event.pull_request.base.sha) }}
     steps:
       -
         run: |


### PR DESCRIPTION
### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable

### Description

Finally, I find the way to concat strings in GitHub Actions Mustache.

<img width="838" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/4197ba4a-0f2a-4299-a45f-e634566a2d7a">

Although this workflow still fails here because **FluxMLBenchmarks** is excluded, theoretically it can run correctly in FluxML/NNlib.jl.

<img width="769" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/abb4fe81-04c8-47d9-85a5-6f0dfa2bf849">