### PR TITLE
Add a comment to the PR triggered Benchmark workflow

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,10 +1,13 @@
 name: Benchmark
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
+      repository:
+        type: string
+        description: name of repository triggers this workflow, e.g. FluxML/NNlib.jl
+      pr_id:
+        type: string
+        description: id of the pull request that triggers this workflow
       target_url:
         type: string
         description: url of target
@@ -52,3 +55,21 @@ jobs:
         with:
           name: report.md
           path: benchmark/report.md
+  Comment:
+    needs: [RunBenchmark]
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.repository != '' && github.event.inputs.pr_id != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Download report
+        uses: actions/download-artifact@v3
+        with:
+          name: report.md
+      -
+        name: Comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          issue-number: ${{ github.event.inputs.pr_id }}
+          token: ${{ secrets.PAT }}
+          body-file: report.md


### PR DESCRIPTION
### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable

### Description

**I'll temporarily NOT merge this PR, for I need some time to validate its feasibility.**

In this PR, I introduced two new inputs, `repository` and `pr_id`, which are both the parameters of `peter-evans/create-or-update-comment`.

The new comment [here](https://github.com/Eternal-Night-Archer/BenchmarkTrigger/pull/1) is also posted by GitHub Actions.

<img width="832" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/17b6d706-0467-44be-971a-bd4aa5f2ad35">

And it was added by [this run](https://github.com/Eternal-Night-Archer/BenchmarkData/actions/runs/5493425598/):

<img width="1408" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/003606ce-73e4-4002-bbd3-36e01e58cf9d">

```yaml
jobs:
  benchmark:
    runs-on: ubuntu-latest
    steps:
      -
        run: |
          echo "# Hello World!" > report.md
      -
        name: Upload report
        uses: actions/upload-artifact@v2
        with:
          name: report.md
          path: report.md
  Comment:
    needs: [benchmark]
    runs-on: ubuntu-latest
    steps:
      -
        name: Download report
        uses: actions/download-artifact@v3
        with:
          name: report.md
      -
        name: Comment
        uses: peter-evans/create-or-update-comment@v2
        with:
          issue-number: ${{ github.event.inputs.pr_id }}
          repository: ${{ github.event.inputs.repository }}
          token: ${{ secrets.PAT }}
          body-file: report.md
```
