### PR TITLE
Update: change second-level spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ e.g.
 ```shell
 > DEPS_LIST="https://github.com/FluxML/NNlib.jl#backports-0.8.21,https://github.com/skyleaworlder/NNlib.jl#dummy-benchmark-test;Flux,Flux@0.13.12"
 > # Only Flux-MLP and all NNlib
-> julia --project=benchmark benchmark/runbenchmarks-cli.jl --enable="flux:mlp;nnlib" --deps-list=$DEPS_LIST
+> julia --project=benchmark benchmark/runbenchmarks-cli.jl --enable="flux(mlp);nnlib" --deps-list=$DEPS_LIST
 > # All benchmarks except Flux, NNlib-gemm and NNlib-activations
-> julia --project=benchmark benchmark/runbenchmarks-cli.jl --disable="flux;nnlib:gemm,activations" --deps-list=$DEPS_LIST
+> julia --project=benchmark benchmark/runbenchmarks-cli.jl --disable="flux;nnlib(gemm,activations)" --deps-list=$DEPS_LIST
 > # Only Flux
 > julia --project=benchmark benchmark/runbenchmarks-cli.jl --enable="flux;nnlib" --disable="nnlib" --deps-list=$DEPS_LIST
 ```

--- a/src/env_utils.jl
+++ b/src/env_utils.jl
@@ -332,7 +332,7 @@ function parse_enabled_benchmarks(
         single_repo_benchmarks = []
         if isempty(segment)
             return single_repo_benchmarks
-        elseif (m = match(r"^(.*?):(.+)$", segment)) !== nothing
+        elseif (m = match(r"^(.*?)\((.+)\)$", segment)) !== nothing
             # e.g. top_level_bg: flux or nnlib
             # e.g. second_level_bgs: activations,gemm
             top_level_bg, second_level_bgs = m.captures[1], m.captures[2]

--- a/test/env_utils_test.jl
+++ b/test/env_utils_test.jl
@@ -84,11 +84,11 @@
         @test length(eb4) == 9      # nnlib(9)
         @test !get(eb3, "FLUXML_BENCHMARK_FLUX", false)
 
-        enable2 = "flux;nnlib:activations"
+        enable2 = "flux;nnlib(activations)"
         eb5 = parse_enabled_benchmarks(enable2, "")
         @test length(eb5) == 4      # flux(2), nnlib(2)
 
-        enable3 = "flux;nnlib:gemm,conv"
+        enable3 = "flux;nnlib(gemm,conv)"
         eb6 = parse_enabled_benchmarks(enable3, "")
         @test length(eb6) == 5      # flux(2), nnlib(3)
 


### PR DESCRIPTION
### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable

### Description

Simply change second-level specification. Previously, using ":" to specify inner level, but now using "( )".

This is because I intend to use the same format as part of artifact's name directly, but upload-artifact action doesn't support ":" existence in file name.

In addition, using parentheses can better express the second level of meaning, which is subordinate to the first level.

(This issue updates the feature in #19)