### PR TITLE
Feat: add `arch` option to support `gpu`

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -48,7 +48,9 @@ jobs:
         name: Install dependencies
         if: ${{ steps.restore-cache.outputs.cache-matched-key == '' }}
         run: |
-          julia --project=benchmark benchmark/runbenchmarks.jl --cache-setup --target=$TARGET_URL --baseline=$BASELINE_URL
+          julia --project=benchmark benchmark/runbenchmarks.jl --cache-setup \
+            --arch=cpu \
+            --target=$TARGET_URL --baseline=$BASELINE_URL
       -
         uses: actions/cache/save@v3
         if: ${{ steps.restore-cache.outputs.cache-matched-key == '' }}
@@ -107,6 +109,7 @@ jobs:
         name: Run benchmark
         run: |
           julia --project=benchmark benchmark/runbenchmarks.jl --pr \
+            --arch=cpu \
             --target=$TARGET_URL --baseline=$BASELINE_URL \
             --enable="${{ matrix.bm }}" \
             --fetch-result
@@ -142,6 +145,7 @@ jobs:
         name: Merge reports
         run: |
           julia --project=benchmark benchmark/runbenchmarks.jl --merge-reports \
+            --arch=cpu \
             --target=$TARGET_URL --baseline=$BASELINE_URL \
             --push-result --push-password=${{ github.token }}
       -

--- a/benchmark/script/mergereports-cli.jl
+++ b/benchmark/script/mergereports-cli.jl
@@ -24,7 +24,7 @@ if parsed_args["push-result"] && suitable_to_use_result_cache(target_url)
     @info "RESULT: $target_url is suitable to push its result to remote"
     writeresults(joinpath(@__DIR__, "..", "result-target.json"), target_benchmarkresults)
     push_result(target_url, joinpath(@__DIR__, "..", "result-target.json")
-              ; git_push_password = parsed_args["push-password"])
+              ; git_push_password = parsed_args["push-password"], arch = parsed_args["arch"])
 end
 
 # generate report.md as the content of comment

--- a/benchmark/script/runbenchmarks-pr.jl
+++ b/benchmark/script/runbenchmarks-pr.jl
@@ -24,7 +24,7 @@ try
         throw("")
     end
 
-    global group_baseline = get_benchmarkresults_from_branch(baseline_url)
+    global group_baseline = get_benchmarkresults_from_branch(baseline_url; arch=parsed_args["arch"])
     if isnothing(group_baseline)
         @warn "RESULT: cannot get result file, run benchmarks"
         throw("")

--- a/src/env_utils.jl
+++ b/src/env_utils.jl
@@ -38,6 +38,13 @@ const FLUXML_AVAILABLE_TOP_LEVEL_BENCHMARKS = [
     "flux", "nnlib"
 ]
 
+"""
+SUPPORTED_ARCHITECTURES means the supported architecture for this tool.
+"""
+const SUPPORTED_ARCHITECTURES = [
+    "cpu", "gpu"
+]
+
 
 """
     Dependency
@@ -256,6 +263,12 @@ function parse_commandline()
         "--push-password"
             help = "used to authenticate when pushing"
             action = :store_arg
+
+        # about architecture
+        "--arch"
+            help = "enable gpu benchmarks"
+            action = :store_arg
+            default = "cpu"
     end
     args = parse_args(s)
     # script-related arguments cli / pr / merge-report / cache-setup
@@ -267,6 +280,10 @@ function parse_commandline()
     args["push-result"] && isnothing(args["push-password"]) &&
         throw(error("Must provide 'push-password' if you want to 'push-result'"))
     
+    # if arch is in SUPPORTED_ARCHITECTURES, allow returning args
+    !(args["arch"] in SUPPORTED_ARCHITECTURES) &&
+        throw(error("--arch must be in SUPPORTED_ARCHITECTURES"))
+
     # if (deps-list) or (target & baseline) specified, allow returning args
     !isnothing(args["deps-list"]) && return args
     !isnothing(args["target"]) && !isnothing(args["baseline"]) &&

--- a/test/env_utils_test.jl
+++ b/test/env_utils_test.jl
@@ -27,7 +27,7 @@
 
     @testset "dependency operation" begin
         init_deps = init_dependencies()
-        @test length(init_deps) == 10
+        @test length(init_deps) == 9
 
         nnlib_dep = Dependency(name = "NNlib", version = "0.8.20")
         fixed_deps = init_dependencies(Vector([nnlib_dep]))


### PR DESCRIPTION
[Please delete this text and describe your change here.
For bugfixes, please detail the bug and include a test case which your patch fixes.
If you are adding a new feature, please clearly describe the design, its rationale, the possible alternatives considered.
It is easiest to merge new features when there is clear precedent in other systems; we need to know we're taking
the right direction since it can be hard to change later.]

### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable

### Description

To distinguish the results of `cpu` and `gpu` (the same `deps-list` would lead to the same result file name), so it's necessary to add `architecture` information in file name.

<img width="913" alt="image" src="https://github.com/FluxML/FluxMLBenchmarks.jl/assets/45269589/1fe66a3c-4ffc-4620-8bb0-eac12d9e64b6">

(corresponding workflow run is [here](https://github.com/FluxML/FluxMLBenchmarks.jl/actions/runs/5889603026/job/15973371531).)