### PR TITLE
Enable NNlib benchmarks again for production

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -71,9 +71,8 @@ jobs:
     strategy:
       matrix:
         bm: [
-          # for test
-          #"nnlib(attention,activations,gemm)", "nnlib(conv)",
-          #"nnlib(pooling,softmax)", "nnlib(dropout,upsample)",
+          "nnlib(attention,activations,gemm)", "nnlib(conv)",
+          "nnlib(pooling,softmax)", "nnlib(dropout,upsample)",
           "flux"
         ]
     steps:


### PR DESCRIPTION
### PR Checklist

- [ ] Tests are added
- [ ] Documentation, if applicable

### Descrption

for FluxML/NNlib.jl#540, @ToucheSir & @jonas208

The NNlib benchmarks were disabled when I was developing our tool, because NNlib benchmarks really take a long time, and at that time, what I wanted is to obtain the results as quickly as possible, thus disabling them.

In this PR, I enable them again. Hopefully it works well!